### PR TITLE
Fix "Open User Data Directory" button not working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.flatpak-builder
+build_dir

--- a/0001-MINETEST_USER_PATH.patch
+++ b/0001-MINETEST_USER_PATH.patch
@@ -1,0 +1,126 @@
+diff --git a/README.md b/README.md
+index 0bc5d4b42..32dacd348 100644
+--- a/README.md
++++ b/README.md
+@@ -98,15 +98,15 @@ Where each location is on each platform:
+ * Windows installed:
+     * `bin`   = `C:\Program Files\Minetest\bin (Depends on the install location)`
+     * `share` = `C:\Program Files\Minetest (Depends on the install location)`
+-    * `user`  = `%APPDATA%\Minetest`
++    * `user`  = `%APPDATA%\Minetest` or `%MINETEST_USER_PATH%`
+ * Linux installed:
+     * `bin`   = `/usr/bin`
+     * `share` = `/usr/share/minetest`
+-    * `user`  = `~/.minetest`
++    * `user`  = `~/.minetest` or `$MINETEST_USER_PATH`
+ * macOS:
+     * `bin`   = `Contents/MacOS`
+     * `share` = `Contents/Resources`
+-    * `user`  = `Contents/User OR ~/Library/Application Support/minetest`
++    * `user`  = `Contents/User` or `~/Library/Application Support/minetest` or `$MINETEST_USER_PATH`
+
+ Worlds can be found as separate folders in: `user/worlds/`
+
+diff --git a/doc/minetest.6 b/doc/minetest.6
+index 27a3d0024..06062721e 100644
+--- a/doc/minetest.6
++++ b/doc/minetest.6
+@@ -124,6 +124,9 @@ Colon delimited list of directories to search for games.
+ .TP
+ .B MINETEST_MOD_PATH
+ Colon delimited list of directories to search for mods.
++.TP
++.B MINETEST_USER_PATH
++Path to Minetest user data directory.
+
+ .SH BUGS
+ Please report all bugs at https://github.com/minetest/minetest/issues.
+diff --git a/src/main.cpp b/src/main.cpp
+index fa4fd604f..401f289df 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -527,7 +527,7 @@ static bool create_userdata_path()
+ 	}
+ #else
+ 	// Create user data directory
+-	success = fs::CreateDir(porting::path_user);
++	success = fs::CreateAllDirs(porting::path_user);
+ #endif
+
+ 	return success;
+diff --git a/src/porting.cpp b/src/porting.cpp
+index 09627431c..f8bd74f9a 100644
+--- a/src/porting.cpp
++++ b/src/porting.cpp
+@@ -422,11 +422,18 @@ bool setSystemPaths()
+ 		path_share += DIR_DELIM "..";
+ 	}
+
+-	// Use "C:\Users\<user>\AppData\Roaming\<PROJECT_NAME_C>"
+-	DWORD len = GetEnvironmentVariable("APPDATA", buf, sizeof(buf));
+-	FATAL_ERROR_IF(len == 0 || len > sizeof(buf), "Failed to get APPDATA");
++	// Use %MINETEST_USER_PATH%
++	DWORD len = GetEnvironmentVariable("MINETEST_USER_PATH", buf, sizeof(buf));
++	FATAL_ERROR_IF(len > sizeof(buf), "Failed to get MINETEST_USER_PATH (too large for buffer)");
++	if (len == 0) {
++		// Use "C:\Users\<user>\AppData\Roaming\<PROJECT_NAME_C>"
++		len = GetEnvironmentVariable("APPDATA", buf, sizeof(buf));
++		FATAL_ERROR_IF(len == 0 || len > sizeof(buf), "Failed to get APPDATA");
++		path_user = std::string(buf) + DIR_DELIM + PROJECT_NAME_C;
++	} else {
++		path_user = std::string(buf);
++	}
+
+-	path_user = std::string(buf) + DIR_DELIM + PROJECT_NAME_C;
+ 	return true;
+ }
+
+@@ -486,8 +493,13 @@ bool setSystemPaths()
+ 	}
+
+ #ifndef __ANDROID__
+-	path_user = std::string(getHomeOrFail()) + DIR_DELIM "."
+-		+ PROJECT_NAME;
++	const char *const minetest_user_path = getenv("MINETEST_USER_PATH");
++	if (minetest_user_path && minetest_user_path[0] != '\0') {
++		path_user = std::string(minetest_user_path);
++	} else {
++		path_user = std::string(getHomeOrFail()) + DIR_DELIM "."
++			+ PROJECT_NAME;
++	}
+ #endif
+
+ 	return true;
+@@ -510,9 +522,14 @@ bool setSystemPaths()
+ 	}
+ 	CFRelease(resources_url);
+
+-	path_user = std::string(getHomeOrFail())
+-		+ "/Library/Application Support/"
+-		+ PROJECT_NAME;
++	const char *const minetest_user_path = getenv("MINETEST_USER_PATH");
++	if (minetest_user_path && minetest_user_path[0] != '\0') {
++		path_user = std::string(minetest_user_path);
++	} else {
++		path_user = std::string(getHomeOrFail())
++			+ "/Library/Application Support/"
++			+ PROJECT_NAME;
++	}
+ 	return true;
+ }
+
+@@ -522,8 +539,13 @@ bool setSystemPaths()
+ bool setSystemPaths()
+ {
+ 	path_share = STATIC_SHAREDIR;
+-	path_user  = std::string(getHomeOrFail()) + DIR_DELIM "."
+-		+ lowercase(PROJECT_NAME);
++	const char *const minetest_user_path = getenv("MINETEST_USER_PATH");
++	if (minetest_user_path && minetest_user_path[0] != '\0') {
++		path_user = std::string(minetest_user_path);
++	} else {
++		path_user  = std::string(getHomeOrFail()) + DIR_DELIM "."
++			+ lowercase(PROJECT_NAME);
++	}
+ 	return true;
+ }

--- a/net.minetest.Minetest.yaml
+++ b/net.minetest.Minetest.yaml
@@ -2,7 +2,7 @@ app-id: net.minetest.Minetest
 runtime: org.freedesktop.Platform
 runtime-version: "22.08"
 sdk: org.freedesktop.Sdk
-command: minetest
+command: run.sh
 rename-appdata-file: net.minetest.minetest.appdata.xml
 rename-desktop-file: net.minetest.minetest.desktop
 rename-icon: minetest
@@ -12,7 +12,6 @@ finish-args:
   - "--socket=pulseaudio"
   - "--device=all"
   - "--share=network"
-  - "--persist=.minetest"
 cleanup:
   - "/include"
   - "/lib/pkgconfig"
@@ -42,19 +41,29 @@ modules:
       - "-DENABLE_CURSES=0"
       - "-DENABLE_GETTEXT=1"
     cleanup:
-      - "/share/minetest/games/minimal"
+      - "/share/minetest/games/devtest"
+    post-install:
+      - install -Dm755 run.sh $FLATPAK_DEST/bin/run.sh
     sources:
       - type: archive
         url: https://github.com/minetest/minetest/archive/5.6.1.tar.gz
-        sha256: 1440603e19dca70e2691e86a74c822ee2c4a36fceee32b2d85ae74772149e9a3
+        sha256: 28894e11a550f52841bf7dacca3cef52c30a79516ce018ffe084fdb730335b3d
 
       - type: archive
         url: https://github.com/minetest/minetest_game/archive/5.6.1.tar.gz
-        sha256: 5dc857003d24bb489f126865fcd6bf0d9c0cb146ca4c1c733570699d15abd0e3
+        sha256: 3e1e2a5e0d28e9958d9881067476d968876343c11b1e89ca6cc6bb88a257a70a
         dest: games/minetest_game
 
       - type: archive
         url: https://github.com/minetest/irrlicht/archive/1.9.0mt8.tar.gz
-        sha256: 27594242da8c7cc1e5ef45922e1dfdd130c37d77719b5d927359eb47992051e0
+        sha256: 77702b997d8b18f75e3f636fa53996ddd5a94c57733ee236d51deccf2d06f3cf
         dest: lib/irrlichtmt
-        
+
+      # This can be removed in 5.7.0+
+      - type: patch
+        path: 0001-MINETEST_USER_PATH.patch
+
+      - type: script
+        dest-filename: run.sh
+        commands:
+          - 'MINETEST_USER_PATH=~/.var/app/net.minetest.Minetest/.minetest exec minetest "$@"'


### PR DESCRIPTION
The problem was that the flatpak internally used `~/.minetest` for the user directory but on the host it is `~/.var/app/net.minetest.Minetest/.minetest`. When Minetest tries to open `~/.minetest`, xdg-desktop-portal is unable to convert this to the host path location (the issue for it to do that is here https://github.com/flatpak/xdg-desktop-portal/issues/591 )

This PR sets MINETEST_USER_DATA to the correct path and removes `--persist`

Fixes #29

## How to test

from CI:

```bash
flatpak install --user https://dl.flathub.org/build-repo/2837/net.minetest.Minetest.flatpakref
flatpak run net.minetest.Minetest
# About > Open User Data Directory
# Try creating a world and making sure it appears in the file manager
```

build locally:

```bash
git clone https://github.com/rubenwardy/net.minetest.Minetest -b fix_open_dir
flatpak-builder --install build-dir net.minetest.Minetest.yaml --user
flatpak run net.minetest.Minetest
# About > Open User Data Directory
# Try creating a world and making sure it appears in the file manager
```