### PR TITLE
Update Minetest to 5.8.0

### DIFF
--- a/net.minetest.Minetest.yaml
+++ b/net.minetest.Minetest.yaml
@@ -51,8 +51,8 @@ modules:
         sha256: 610c85a24d77acdc3043a69d777bed9e6c00169406ca09df22ad490fe0d68c0c
 
       - type: archive
-        url: https://github.com/minetest/irrlicht/archive/1.9.0mt10.tar.gz
-        sha256: 6d00348d8ff513f6a7cee5c930908ef67428ff637e6a9e4d5688409bdb6d547d
+        url: https://github.com/minetest/irrlicht/archive/1.9.0mt13.tar.gz
+        sha256: 2fde8e27144988210b9c0ff1e202905834d9d25aaa63ce452763fd7171096adc
         dest: lib/irrlichtmt
 
       - type: script

--- a/net.minetest.Minetest.yaml
+++ b/net.minetest.Minetest.yaml
@@ -47,8 +47,8 @@ modules:
       - install -Dm755 minetest.sh $FLATPAK_DEST/bin/minetest
     sources:
       - type: archive
-        url: https://github.com/minetest/minetest/archive/5.7.0.tar.gz
-        sha256: 0cd0fd48a97f76e337a2e1284599a054f8f92906a84a4ef2122ed321e1b75fa7
+        url: https://github.com/minetest/minetest/archive/5.8.0.tar.gz
+        sha256: 610c85a24d77acdc3043a69d777bed9e6c00169406ca09df22ad490fe0d68c0c
 
       - type: archive
         url: https://github.com/minetest/minetest_game/archive/5.7.0.tar.gz

--- a/net.minetest.Minetest.yaml
+++ b/net.minetest.Minetest.yaml
@@ -51,11 +51,6 @@ modules:
         sha256: 610c85a24d77acdc3043a69d777bed9e6c00169406ca09df22ad490fe0d68c0c
 
       - type: archive
-        url: https://github.com/minetest/minetest_game/archive/5.7.0.tar.gz
-        sha256: 0787b24cf7b340a8a2be873ca3744cec60c2683011f1d658350a031d1bd5976d
-        dest: games/minetest_game
-
-      - type: archive
         url: https://github.com/minetest/irrlicht/archive/1.9.0mt10.tar.gz
         sha256: 6d00348d8ff513f6a7cee5c930908ef67428ff637e6a9e4d5688409bdb6d547d
         dest: lib/irrlichtmt


### PR DESCRIPTION
The minetest and irrlicht was updated... the game isn't needed.

Idk about update the luajit. 